### PR TITLE
README.markdown Clarifications and Corrections

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -4,7 +4,7 @@
 
 ##Installation
 
-The simplest way to get started with ruboto-irb is to install a prebuilt binary package.  They can be found at [github.com/ruboto/ruboto-irb/downloads](http://github.com/ruboto/ruboto-irb/downloads).
+The simplest way to get started with ruboto-irb is to install a prebuilt binary package.  These packages can be found at [github.com/ruboto/ruboto-irb/downloads](http://github.com/ruboto/ruboto-irb/downloads).
 
 If you'd like more control over the build and installation process, you can do it manually using the following instructions.
 


### PR DESCRIPTION
Hi, all.  I had a really hard time understanding the README.  Here's my revised version with the following changes:
- The easiest path, the use of the prebuilt binary, is now stated at the beginning instead of the end of the installation instructions.
- Some of the commands and information that appear to be obsolete were updated (e.g. changing "ant install" to "ant debug install").
- Used subheadings and italics to more clearly (IMO) organize and express the content.
- Clarified some descriptive text.

It wasn't clear to me whether or not the note about version 4 applies to versions prior to 4.  There's a question in the text about it that should be removed when we know.

(I tested this a few times, but please do check my work.)
